### PR TITLE
chore: send string to fastAPI instead of object.

### DIFF
--- a/packages/server/src/helpers/utils.ts
+++ b/packages/server/src/helpers/utils.ts
@@ -1,0 +1,57 @@
+import fs from 'fs'
+import { v4 as uuidv4 } from 'uuid'
+import { Attachment } from '@app/adapters/api/types'
+import { setAttachmentInDb } from '@app/adapters/api/databaseHelper'
+import { ErrorReportType, IErrorReportFiles } from '@app/services/types'
+
+export function getErrorReportString(data: ErrorReportType) {
+  const description = Object.values(data).reduce((prev, curr, index) => {
+    if (index === 0) return prev.concat('', curr)
+    if (!curr) return prev
+    if (data.description && data.description === curr)
+      return prev.concat(': ', curr)
+
+    return prev.concat(' -> ', curr)
+  }, '')
+
+  return description
+}
+
+export async function addFilesToDb(data: IErrorReportFiles, reportId: string) {
+  const getExt = (type: string) => {
+    //To do: add more types? Video osv.
+    switch (type) {
+      case 'image/jpeg':
+        return 'jpg'
+      case 'image/png':
+        return 'png'
+      default:
+        return 'Unvalid type'
+    }
+  }
+  let imagePath, videoPath
+  if (data.image) {
+    const ext = getExt(data.image.type) // check MIME TYPE
+    imagePath = `attachments/${uuidv4()}.${ext}`
+    fs.renameSync(data.image.path, imagePath)
+  } else {
+    imagePath = ''
+  }
+
+  if (data.video) {
+    const ext = getExt(data.video.type) // check MIME TYPE
+    videoPath = `attachments/${uuidv4()}.${ext}`
+    fs.renameSync(data.video.path, videoPath)
+  } else {
+    videoPath = ''
+  }
+
+  if (imagePath || videoPath) {
+    const attachment: Attachment = {
+      error_report_id: reportId || '',
+      photo: imagePath,
+      video: videoPath,
+    }
+    await setAttachmentInDb(attachment)
+  }
+}

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -7,7 +7,8 @@ import {
   fetchApiRooms,
   postCase,
 } from '@app/services/fastapi'
-import { Area, ErrorReportType } from '@app/services/types'
+import { Area, ErrorReportType, IErrorReportFiles } from '@app/services/types'
+import { addFilesToDb } from '@app/helpers/utils'
 
 export const routes = (app: Application) => {
   app.get(
@@ -99,14 +100,19 @@ export const routes = (app: Application) => {
         room: req.fields?.room as string,
         area: req.fields?.area as string,
         object: req.fields?.object as string,
-        complete: {
-          text: req.fields?.text as string,
-          image: req.files?.image,
-          video: req.files?.video,
-        },
+        description: req.fields?.text as string,
       }
 
+      const files: IErrorReportFiles = {
+        image: req.files?.image,
+        video: req.files?.video,
+      }
       const errorReport = await postCase(data)
+
+      if (errorReport.id) {
+        addFilesToDb(files, errorReport.id)
+      }
+
       if ('message' in errorReport) {
         res.status(400)
       }

--- a/packages/server/src/services/fastapi.ts
+++ b/packages/server/src/services/fastapi.ts
@@ -1,10 +1,6 @@
 import { client } from '@app/adapters/api'
 import { Room, Inventory, ErrorReportType, ApiExceptionType } from './types'
-import { setAttachmentInDb } from '../adapters/api/databaseHelper'
-import { Attachment } from '@app/adapters/api/types'
-import fs from 'fs'
-import { Fields, Files } from 'formidable'
-import { v4 as uuidv4 } from 'uuid'
+import { getErrorReportString } from '@app/helpers/utils'
 
 export const fetchApiRooms = async (rentalId: string): Promise<Array<Room>> => {
   const rooms: Array<Room> = await client.get({
@@ -25,56 +21,14 @@ export const fetchApiInventory = async (
 export const postCase = async (
   data: ErrorReportType
 ): Promise<ErrorReportType | ApiExceptionType> => {
-  // console.log('data', data)
   try {
     // To do: post data into slussen and get id and use
+    const description = getErrorReportString(data)
     const createdErrorReport = await client.post({
       url: 'cases',
-      data,
+      data: description,
     })
-    const { id } = createdErrorReport
 
-    if (id && (data.complete.image || data.complete.video)) {
-      // console.log('img', data.complete.image)
-    }
-
-    const getExt = (type: string) => {
-      //To do: add more types? Video osv.
-      switch (type) {
-        case 'image/jpeg':
-          return 'jpg'
-        case 'image/png':
-          return 'png'
-        default:
-          return 'Unvalid type'
-      }
-    }
-
-    let imagePath, videoPath
-    if (data.complete.image) {
-      const ext = getExt(data.complete.image.type) // check MIME TYPE
-      imagePath = `attachments/${uuidv4()}.${ext}`
-      fs.renameSync(data.complete.image.path, imagePath)
-    } else {
-      imagePath = ''
-    }
-
-    if (data.complete.video) {
-      const ext = getExt(data.complete.video.type) // check MIME TYPE
-      videoPath = `attachments/${uuidv4()}.${ext}`
-      fs.renameSync(data.complete.video.path, videoPath)
-    } else {
-      videoPath = ''
-    }
-
-    if (imagePath || videoPath) {
-      const attachment: Attachment = {
-        error_report_id: id,
-        photo: imagePath,
-        video: videoPath,
-      }
-      await setAttachmentInDb(attachment)
-    }
     return <ErrorReportType>createdErrorReport
   } catch (e: any) {
     console.log('error', e.response)

--- a/packages/server/src/services/types.ts
+++ b/packages/server/src/services/types.ts
@@ -7,10 +7,10 @@ export interface Room {
 
 export type ApiExceptionType = {
   message: string
+  id?: string
 }
 
-export interface IFormData {
-  text?: string
+export interface IErrorReportFiles {
   image?: any
   video?: any
 }
@@ -20,7 +20,7 @@ export interface ErrorReportType {
   room: string
   area: string
   object: string
-  complete: IFormData
+  description?: string
 }
 
 export const InventoryClassification: { [index: string]: string } = {


### PR DESCRIPTION
Instead of sending the whole error report object to slussen, we send a string of a description. 
`Lägenhet -> Kök -> Övrigt: lampan är trasig`