### PR TITLE
chore: change case format

### DIFF
--- a/packages/server/src/helpers/utils.ts
+++ b/packages/server/src/helpers/utils.ts
@@ -1,6 +1,6 @@
-import { ErrorReportType } from '@app/services/types'
+import { ErrorReportInput } from '@app/services/types'
 
-export function getErrorReportString(data: ErrorReportType) {
+export function getErrorReportString(data: ErrorReportInput) {
   const description = Object.values(data).reduce((prev, curr, index) => {
     if (index === 0) return prev.concat('', curr)
     if (!curr) return prev

--- a/packages/server/src/helpers/utils.ts
+++ b/packages/server/src/helpers/utils.ts
@@ -1,0 +1,14 @@
+import { ErrorReportType } from '@app/services/types'
+
+export function getErrorReportString(data: ErrorReportType) {
+  const description = Object.values(data).reduce((prev, curr, index) => {
+    if (index === 0) return prev.concat('', curr)
+    if (!curr) return prev
+    if (data.description && data.description === curr)
+      return prev.concat(': ', curr)
+
+    return prev.concat(' -> ', curr)
+  }, '')
+
+  return description
+}

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -7,7 +7,7 @@ import {
   fetchApiRooms,
   postCase,
 } from '@app/services/fastapi'
-import { Area, ErrorReportType } from '@app/services/types'
+import { Area, ErrorReportType, IFormData } from '@app/services/types'
 
 export const routes = (app: Application) => {
   app.get(
@@ -103,14 +103,14 @@ export const routes = (app: Application) => {
         area: req.fields?.area as string,
         object: req.fields?.object as string,
         rentalId: req.fields?.rentalId as string,
-        complete: {
-          text: req.fields?.text as string,
-          image: req.files?.image,
-          video: req.files?.video,
-        },
+        description: req.fields?.text as string,
+      }
+      const complete: IFormData = {
+        image: req.files?.image,
+        video: req.files?.video,
       }
 
-      const errorReport = await postCase(data)
+      const errorReport = await postCase(data, complete)
       if ('message' in errorReport) {
         res.status(400).send(errorReport)
         return

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -7,7 +7,7 @@ import {
   fetchApiRooms,
   postCase,
 } from '@app/services/fastapi'
-import { Area, ErrorReportType, IFormData } from '@app/services/types'
+import { Area, ErrorReportType } from '@app/services/types'
 
 export const routes = (app: Application) => {
   app.get(
@@ -98,19 +98,21 @@ export const routes = (app: Application) => {
     authMiddleware,
     asyncHandler(async (req: Request, res: Response) => {
       const data: ErrorReportType = {
-        place: req.fields?.place as string,
-        room: req.fields?.room as string,
-        area: req.fields?.area as string,
-        object: req.fields?.object as string,
         rentalId: req.fields?.rentalId as string,
-        description: req.fields?.text as string,
-      }
-      const complete: IFormData = {
-        image: req.files?.image,
-        video: req.files?.video,
+        input: {
+          place: req.fields?.place as string,
+          room: req.fields?.room as string,
+          area: req.fields?.area as string,
+          object: req.fields?.object as string,
+          description: req.fields?.text as string,
+        },
+        complete: {
+          image: req.files?.image,
+          video: req.files?.video,
+        },
       }
 
-      const errorReport = await postCase(data, complete)
+      const errorReport = await postCase(data)
       if ('message' in errorReport) {
         res.status(400).send(errorReport)
         return

--- a/packages/server/src/services/fastapi.ts
+++ b/packages/server/src/services/fastapi.ts
@@ -1,5 +1,5 @@
 import { client } from '@app/adapters/api'
-import { Room, Inventory, ErrorReportType, ApiExceptionType } from './types'
+import { Room, Inventory, ErrorReportType, ApiExceptionType, IFormData } from './types'
 import { setAttachmentInDb } from '../adapters/api/databaseHelper'
 import { Attachment } from '@app/adapters/api/types'
 import fs from 'fs'
@@ -32,7 +32,8 @@ export const fetchApiInventory = async (
 }
 
 export const postCase = async (
-  data: ErrorReportType
+  data: ErrorReportType,
+  complete: IFormData
 ): Promise<ErrorReportType | ApiExceptionType> => {
   const description = getErrorReportString(data)
   try {
@@ -41,7 +42,7 @@ export const postCase = async (
       data: description,
     })
 
-    if (createdErrorReport.id && (data.complete.image || data.complete.video)) {
+    if (createdErrorReport.id && (complete.image || complete.video)) {
       // console.log('img', data.complete.image)
     }
 
@@ -58,18 +59,18 @@ export const postCase = async (
     }
 
     let imagePath, videoPath
-    if (data.complete.image) {
-      const ext = getExt(data.complete.image.type) // check MIME TYPE
+    if (complete.image) {
+      const ext = getExt(complete.image.type) // check MIME TYPE
       imagePath = `attachments/${uuidv4()}.${ext}`
-      fs.renameSync(data.complete.image.path, imagePath)
+      fs.renameSync(complete.image.path, imagePath)
     } else {
       imagePath = ''
     }
 
-    if (data.complete.video) {
-      const ext = getExt(data.complete.video.type) // check MIME TYPE
+    if (complete.video) {
+      const ext = getExt(complete.video.type) // check MIME TYPE
       videoPath = `attachments/${uuidv4()}.${ext}`
-      fs.renameSync(data.complete.video.path, videoPath)
+      fs.renameSync(complete.video.path, videoPath)
     } else {
       videoPath = ''
     }

--- a/packages/server/src/services/fastapi.ts
+++ b/packages/server/src/services/fastapi.ts
@@ -1,5 +1,5 @@
 import { client } from '@app/adapters/api'
-import { Room, Inventory, ErrorReportType, ApiExceptionType, IFormData } from './types'
+import { Room, Inventory, ErrorReportType, ApiExceptionType } from './types'
 import { setAttachmentInDb } from '../adapters/api/databaseHelper'
 import { Attachment } from '@app/adapters/api/types'
 import fs from 'fs'
@@ -33,13 +33,14 @@ export const fetchApiInventory = async (
 
 export const postCase = async (
   data: ErrorReportType,
-  complete: IFormData
 ): Promise<ErrorReportType | ApiExceptionType> => {
-  const description = getErrorReportString(data)
+  const {rentalId, input, complete} = data
+  const description = getErrorReportString(input)
+
   try {
     const createdErrorReport = await client.post({
       url: 'cases',
-      data: description,
+      data: {description, rentalId},
     })
 
     if (createdErrorReport.id && (complete.image || complete.video)) {

--- a/packages/server/src/services/fastapi.ts
+++ b/packages/server/src/services/fastapi.ts
@@ -5,6 +5,7 @@ import { Attachment } from '@app/adapters/api/types'
 import fs from 'fs'
 import { Fields, Files } from 'formidable'
 import { v4 as uuidv4 } from 'uuid'
+import { getErrorReportString } from '@app/helpers/utils'
 
 export const fetchApiRooms = async (
   rentalId: string,
@@ -33,10 +34,11 @@ export const fetchApiInventory = async (
 export const postCase = async (
   data: ErrorReportType
 ): Promise<ErrorReportType | ApiExceptionType> => {
+  const description = getErrorReportString(data)
   try {
     const createdErrorReport = await client.post({
       url: 'cases',
-      data,
+      data: description,
     })
 
     if (createdErrorReport.id && (data.complete.image || data.complete.video)) {

--- a/packages/server/src/services/types.ts
+++ b/packages/server/src/services/types.ts
@@ -9,18 +9,23 @@ export type ApiExceptionType = {
   message: string
 }
 
-export interface IFormData {
+export interface ErrorReportMedia {
   image?: any
   video?: any
 }
-export interface ErrorReportType {
+
+export interface ErrorReportInput {
   id?: string
   place: string
   room: string
   area: string
   object: string
+  description?: string
+}
+export interface ErrorReportType {
   rentalId: string
-  description: string
+  input: ErrorReportInput
+  complete: ErrorReportMedia
 }
 
 export const InventoryClassification: { [index: string]: string } = {

--- a/packages/server/src/services/types.ts
+++ b/packages/server/src/services/types.ts
@@ -10,7 +10,6 @@ export type ApiExceptionType = {
 }
 
 export interface IFormData {
-  text?: string
   image?: any
   video?: any
 }
@@ -20,8 +19,8 @@ export interface ErrorReportType {
   room: string
   area: string
   object: string
-  complete: IFormData
   rentalId: string
+  description: string
 }
 
 export const InventoryClassification: { [index: string]: string } = {


### PR DESCRIPTION
Instead of sending the whole error report object to slussen, we send a string of a description.
`Lägenhet -> Kök -> Övrigt: lampan är trasig`