### PR TITLE
fix: handling icons

### DIFF
--- a/packages/client/src/components/Icon.tsx
+++ b/packages/client/src/components/Icon.tsx
@@ -75,9 +75,13 @@ const Wrapper = styled.div`
 
 const Icon = ({ name, alt }: Props) => {
   const getIconName = () => {
-    const iconName = Object.keys(IconName).filter((a) => name.includes(a))[0] ?? 'Övrigt'
+    const sanitizedName = Object.keys(IconName).filter((a) => Boolean(name.includes(a)))
+    const iconName =
+      sanitizedName.length === 1
+        ? IconName[sanitizedName[0] as keyof typeof IconName]
+        : IconName['Övrigt' as keyof typeof IconName]
 
-    return Icons[IconName[iconName as keyof typeof IconName]]
+    return Icons[iconName]
   }
 
   return (

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -58,8 +58,10 @@ export const routes = (app: Application) => {
       const inventory = await fetchApiInventory(req.query.roomId as string)
       const classCode = req.query.inventoryCode
 
-      const filteredData = inventory.filter((a) => a.class.code === classCode)
-
+      const filteredData = inventory.filter((a) => {
+        if (typeof a.description === 'object') a.description = a.id
+        return a.class.code === classCode
+      })
       res.send(filteredData)
     }),
     errorHandler


### PR DESCRIPTION
Problem: app crashed when using `OBJ-07020304` as rental id. This was because description was an empty object instead of a string, that we expect. 

Extra: Also fixed how we get icons and how we use the default icon `•••`. When receiving a number ex. `234` the filter function returned `["4", "3", "2"]`. 